### PR TITLE
allow fully-qualified Field names like checkout[note]

### DIFF
--- a/src/Fields/Field.js
+++ b/src/Fields/Field.js
@@ -74,6 +74,11 @@ export default class Field extends HTMLDivElement{
 
             let fieldId = `checkout_attributes_${name}`;
             let fieldName = `checkout[attributes][${name}]`;
+            // handle fully-qualified names like checkout[note] and checkout[attributes][buyer_is_cool]
+            if (name.startsWith('checkout[') && name.endsWith(']')) {
+                fieldId = name.replace('][','_').replace('[','_').replace(']','')
+                fieldName = name;
+            }
 
             let element = document.createElement('div');
             element.classList.add(classes.field);


### PR DESCRIPTION

What do you think of this as a possible solution to https://github.com/adearriba/ShopifyCheckoutJS/issues/2 ?

It keeps the current naming of `fieldId` and `fieldName` unless the `name` prop matches `checkout[.*]`, in which case it uses the `name` as-is  for `fieldName`, e.g. 
- `customer_is_cool` => `checkout[attributes][customer_is_cool]`
- `checkout[note]` => `checkout[note]`
- `checkout[attributes][customer_is_cool]` => `checkout[attributes][customer_is_cool]`

and it sets `fieldId` to snake-case representation of name, e.g.
  -  `checkout[note]` => `checkout_note` 
  - `checkout[attributes][customer_is_cool]` => `checkout_attributes_customer_is_cool`